### PR TITLE
remove JSON.parse() from tryReplace()

### DIFF
--- a/src/BulkImportScript.js
+++ b/src/BulkImportScript.js
@@ -40,9 +40,8 @@ function bulkImport(docs, upsert) {
             
     // To replace the document, first issue a query to find it and then call replace.
     function tryReplace(doc, callback) {
-        var parsedDoc = JSON.parse(doc);
-        retrieveDoc(parsedDoc, null, function(retrievedDocs){
-            var isAccepted = collection.replaceDocument(retrievedDocs[0]._self, parsedDoc, callback);
+        retrieveDoc(doc, null, function(retrievedDocs) {
+            var isAccepted = collection.replaceDocument(retrievedDocs[0]._self, doc, callback);
             if (!isAccepted) getContext().getResponse().setBody(count);
         });
     }


### PR DESCRIPTION
`doc` in `tryReplace()` is an object. Parsing it causes an error.

Usage is same as `tryCreate()`, which takes an object.
See:
https://github.com/Azure/azure-documentdb-hadoop/blob/master/src/BulkImportScript.js#L23
https://github.com/Azure/azure-documentdb-hadoop/blob/master/src/BulkImportScript.js#L74